### PR TITLE
Use {} instead of {new = new} for module table.

### DIFF
--- a/Input.lua
+++ b/Input.lua
@@ -184,4 +184,4 @@ function Input:gamepadaxis(joystick, axis, newvalue)
     self.state[button_to_axis[axis]] = newvalue
 end
 
-return setmetatable({new = new}, {__call = function(_, ...) return Input.new(...) end})
+return setmetatable({}, {__call = function(_, ...) return Input.new(...) end})


### PR DESCRIPTION
Unless something has gone over my head here, `{new = new}` does nothing. Since `new` is an undeclared variable, effectively it's the same as `{new = nil}`?

`{new = new}` breaks strict.lua (http://metalua.luaforge.net/src/lib/strict.lua.html), so I figure that changing this could save some other people a minor annoyance.
