### PR TITLE
Add basic multiple controller support

### DIFF
--- a/Input.lua
+++ b/Input.lua
@@ -76,7 +76,7 @@ end
 function Input:pressed(action)
     if action then
         for _, key in ipairs(self.binds[action]) do
-            if self:down(action) and not self.prev_state[key] then
+            if self.state[key] and not self.prev_state[key] then
                 return true
             end
         end

--- a/Input.lua
+++ b/Input.lua
@@ -76,7 +76,7 @@ end
 function Input:pressed(action)
     if action then
         for _, key in ipairs(self.binds[action]) do
-            if self.state[key] and not self.prev_state[key] then
+            if self:down(action) and not self.prev_state[key] then
                 return true
             end
         end
@@ -179,7 +179,8 @@ function Input:down(action, interval, delay)
                 return true
             end
 
-            local joystick = self.joysticks[self.joystick_index]
+            local joystick = love.joystick.getJoysticks()[self.joystick_index]
+
             if joystick then
                 if axis_to_button[key] then
                     return self.state[key]
@@ -244,6 +245,10 @@ function Input:setJoystickIndex(index)
   self.joystick_index = index
 end
 
+function Input:isJoystickConnected()
+  return love.joystick.getJoysticks()[self.joystick_index] ~= nil
+end
+
 function Input:keypressed(key)
     self.state[key] = true
 end
@@ -274,18 +279,24 @@ local button_to_gamepad = {a = 'fdown', y = 'fup', x = 'fleft', b = 'fright', ba
                            dpup = 'dpup', dpdown = 'dpdown', dpleft = 'dpleft', dpright = 'dpright'}
 
 function Input:gamepadpressed(joystick, button)
+  if joystick == self.joysticks[self.joystick_index] then
     self.state[button_to_gamepad[button]] = true
+  end
 end
 
 function Input:gamepadreleased(joystick, button)
+  if joystick == self.joysticks[self.joystick_index] then
     self.state[button_to_gamepad[button]] = false
     self.repeat_state[button_to_gamepad[button]] = false
+  end
 end
 
 local button_to_axis = {leftx = 'leftx', lefty = 'lefty', rightx = 'rightx', righty = 'righty', triggerleft = 'l2', triggerright = 'r2'}
 
 function Input:gamepadaxis(joystick, axis, newvalue)
+  if joystick == self.joysticks[self.joystick_index] then
     self.state[button_to_axis[axis]] = newvalue
+  end
 end
 
 return setmetatable({}, {__call = function(_, ...) return Input.new(...) end})

--- a/README.md
+++ b/README.md
@@ -106,7 +106,106 @@ input:unbind('mouse1')
 
 Unbinding keys simply disconnects them from their actions. You can also use `input:unbindAll()` to unbind all bound keys.
 
-<br>
+<br>  
+  
+### Using multiple controllers  
+  
+```lua  
+local input = Input({joystick_index = 1})
+```  
+  
+Creating an `Input` instance like so allows you to define what index that the joystick belongs to (joystick 1 would be the first joystick to be connected, joystick 2 would be the second, etc).  
+You can also use `input:setJoystickIndex(index)` to set the index later.  
+Setting a joystick index to a controller that doesn't exit (yet) doesn't cause an error (but it still doesn't return true for any input events), so if you want to make sure that a controller is connected you can use `input:isJoystickConnected()` to check if a joystick is actually connected.  
+  
+<br>  
+  
+### Examples  
+  
+#### Using multiple player controllers in a multiplayer game  
+  
+Let's say that you want a character select screen where if anyone connects their controller and taps the "join" button, they'll join the game.  
+Here's one way to acheive that with this library:  
+
+```lua 
+-- your update function
+function update()
+  for _, input in pairs(playerInputs) do
+    if input:pressed("join") then
+      -- do player instantiation and input setting code here
+    end
+  end
+end
+
+local playerInputs = {}
+
+for i = 1, 4 do
+  local input = Input()
+  input:setJoystickIndex(i)
+  input:bind("fdown", "join")
+  playerInputs[i] = input
+end
+```  
+  
+#### Platformer character controls  
+  
+Platformers usually have very fluid controls that give the player lots of freedom. Thanks to this library's nature, it's very easy to get started with freeform platformer controls.
+
+```lua  
+local input = Input()
+input:bind("right", "move_right")
+input:bind("left", "move_left")
+input:bind("x", "jump")
+input:bind("c", "shoot")
+
+-- your update function
+function update()
+   -- charge shoot attack
+   if input:down("shoot", .5) then
+    shootPower = shootPower + 1
+   end
+   
+   -- then release!
+   if input:released("shoot") then
+    shootBullet(shootPower)
+    shootPower = 0
+   end
+
+   -- general movement code
+   if input:down("move_right") then
+    if vx < 0 then vx = vx + deacceleration end
+    if vx < topSpeed then vx = vx + acceleration end
+   elseif input:down("move_left") then
+    if vx > 0 then vx = vx - deacceleration end
+    if vx > -topSpeed then vx = vx - acceleration end
+   else
+    vx = vx - math.min(math.abs(vx), friction) * (vx >= 0 and 1 or -1)
+   end
+   
+   -- dashing sequences
+   if input:sequence("move_right", .4, "move_right") then dashRight() end
+   if input:sequence("move_left", .4, "move_left") then dashLeft() end
+   
+   -- apply gravity
+   vy = vy - gravity
+   
+   -- jumping
+   if input:pressed("jump") and grounded then
+    vy = maxJumpHeight
+   end
+   
+   -- multiple jump heights
+   if input:released("jump") and not grounded and vy > minJumpHeight then
+    vy = minJumpHeight
+   end
+   
+   -- translate player here
+   
+   if grounded then vy = 0 end
+end
+```  
+  
+<br>  
 
 ### Key/mouse/gamepad Constants
 

--- a/README.md
+++ b/README.md
@@ -147,66 +147,8 @@ for i = 1, 4 do
 end
 ```  
   
-#### Platformer character controls  
+<br>
   
-Platformers usually have very fluid controls that give the player lots of freedom. Thanks to this library's nature, it's very easy to get started with freeform platformer controls.
-
-```lua  
-local input = Input()
-input:bind("right", "move_right")
-input:bind("left", "move_left")
-input:bind("x", "jump")
-input:bind("c", "shoot")
-
--- your update function
-function update()
-   -- charge shoot attack
-   if input:down("shoot", .5) then
-    shootPower = shootPower + 1
-   end
-   
-   -- then release!
-   if input:released("shoot") then
-    shootBullet(shootPower)
-    shootPower = 0
-   end
-
-   -- general movement code
-   if input:down("move_right") then
-    if vx < 0 then vx = vx + deacceleration end
-    if vx < topSpeed then vx = vx + acceleration end
-   elseif input:down("move_left") then
-    if vx > 0 then vx = vx - deacceleration end
-    if vx > -topSpeed then vx = vx - acceleration end
-   else
-    vx = vx - math.min(math.abs(vx), friction) * (vx >= 0 and 1 or -1)
-   end
-   
-   -- dashing sequences
-   if input:sequence("move_right", .4, "move_right") then dashRight() end
-   if input:sequence("move_left", .4, "move_left") then dashLeft() end
-   
-   -- apply gravity
-   vy = vy - gravity
-   
-   -- jumping
-   if input:pressed("jump") and grounded then
-    vy = maxJumpHeight
-   end
-   
-   -- multiple jump heights
-   if input:released("jump") and not grounded and vy > minJumpHeight then
-    vy = minJumpHeight
-   end
-   
-   -- translate player here
-   
-   if grounded then vy = 0 end
-end
-```  
-  
-<br>  
-
 ### Key/mouse/gamepad Constants
 
 Keyboard constants are unchanged from [here](https://www.love2d.org/wiki/KeyConstant), but mouse and gamepad have been changed to the following:


### PR DESCRIPTION
Adds really rudimentary multiple controller support.  
You can use it as such:  
  
```lua  
local input = Input( { joystick_index = 1 } )
input:setJoystickIndex(2)
```  
  
This hasn't gone through intensive testing, and doesn't cause an error if it gets a controller that doesn't exist (since it's possible that it might later).