### PR TITLE
Support unbinding of anonymous functions

### DIFF
--- a/Input.lua
+++ b/Input.lua
@@ -200,10 +200,14 @@ function Input:unbind(key)
             end
         end
     end
+    if self.functions[key] then
+        self.functions[key] = nil
+    end
 end
 
 function Input:unbindAll()
     self.binds = {}
+    self.functions = {}
 end
 
 local copy = function(t1)


### PR DESCRIPTION
Setting functions[key] to nil should be enough to allow
unbinding/rebinding of anonymous functions to a key. Also clearing the
functions table in unbindAll will unbind all functions for keys.